### PR TITLE
refactor: remove process::exit from library code, return Result instead

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// Missing file
     #[error("Missing file: {0}")]
     MissingFile(String),
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
     /// Something else happened
     #[error("Unknown error: {0}")]
     Unknown(String),


### PR DESCRIPTION
## Changes

- Remove all 5 `std::process::exit(1)` calls from `src/config.rs`
- `RLLVMConfig::new()` and `load_path()` now return `Result<Self, Error>`
- New `try_default()` fallible method extracted from `Default::default()`
- Added `ConfigError(String)` variant to `Error` enum
- Panic boundary pushed to `rllvm_config()` OnceLock init (appropriate for global singleton)
- Binary files unchanged — `process::exit` is fine there

## Why

Library code should never call `process::exit()` — it prevents callers from handling errors gracefully. This is especially important for users who may want to use rllvm as a library.