### PR TITLE
refactor: remove process::exit from library code

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// Missing file
     #[error("Missing file: {0}")]
     MissingFile(String),
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
     /// Something else happened
     #[error("Unknown error: {0}")]
     Unknown(String),


### PR DESCRIPTION
Replace `process::exit(1)` calls in `config.rs` with proper `Result<>` error propagation. Library code should never call process::exit; let binaries decide.