### PR TITLE
refactor: replace unimplemented/expect/unwrap with proper error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
     /// Logger error
     #[error("Logger error: {0}")]
     LoggerError(String),
+    /// Unsupported binary format
+    #[error("Unsupported binary format: {0}")]
+    UnsupportedBinaryFormat(String),
     /// Missing file
     #[error("Missing file: {0}")]
     MissingFile(String),

--- a/src/utils/file_utils.rs
+++ b/src/utils/file_utils.rs
@@ -69,7 +69,12 @@ where
             DARWIN_SECTION_NAME.as_bytes().to_vec(),
             SectionFlags::MachO { flags: 0 },
         ),
-        _ => unimplemented!(),
+        _ => {
+            return Err(Error::UnsupportedBinaryFormat(format!(
+                "{:?}",
+                object_binary_format
+            )));
+        }
     };
 
     // Copy the input object file into a new mutable object file
@@ -90,7 +95,7 @@ where
     // supported for auto inferring flags
     new_section.flags = flags;
 
-    let output_data = new_object_file.write().unwrap();
+    let output_data = new_object_file.write()?;
     if let Some(output_object_filepath) = output_object_filepath {
         // Save the new object file
         fs::write(output_object_filepath, output_data)?;
@@ -274,7 +279,12 @@ pub fn extract_bitcode_filepaths_from_parsed_object(
     let section_name = match object_binary_format {
         BinaryFormat::Elf => ELF_SECTION_NAME.as_bytes(),
         BinaryFormat::MachO => DARWIN_SECTION_NAME.as_bytes(),
-        _ => unimplemented!("unsupported binary format: {:?}", object_binary_format),
+        _ => {
+            return Err(Error::UnsupportedBinaryFormat(format!(
+                "{:?}",
+                object_binary_format
+            )));
+        }
     };
 
     match object_file.section_by_name_bytes(section_name) {

--- a/src/utils/path_utils.rs
+++ b/src/utils/path_utils.rs
@@ -24,21 +24,44 @@ where
     }
 
     // Parent directory
-    let parent_dir = src_filepath
-        .parent()
-        .unwrap_or_else(|| panic!("Failed to obtain the parent directory: {:?}", src_filepath));
+    let parent_dir = src_filepath.parent().ok_or_else(|| {
+        Error::InvalidArguments(format!(
+            "Failed to obtain the parent directory: {:?}",
+            src_filepath
+        ))
+    })?;
     // With extension
     let file_name = src_filepath
         .file_name()
-        .unwrap_or_else(|| panic!("Failed to obtain the file name: {:?}", src_filepath))
+        .ok_or_else(|| {
+            Error::InvalidArguments(format!(
+                "Failed to obtain the file name: {:?}",
+                src_filepath
+            ))
+        })?
         .to_str()
-        .unwrap_or_else(|| panic!("Failed to convert OsStr to str: {:?}", src_filepath));
+        .ok_or_else(|| {
+            Error::InvalidArguments(format!(
+                "Failed to convert OsStr to str: {:?}",
+                src_filepath
+            ))
+        })?;
     // Without extension
     let file_stem = src_filepath
         .file_stem()
-        .unwrap_or_else(|| panic!("Failed to obtain the file stem: {:?}", src_filepath))
+        .ok_or_else(|| {
+            Error::InvalidArguments(format!(
+                "Failed to obtain the file stem: {:?}",
+                src_filepath
+            ))
+        })?
         .to_str()
-        .unwrap_or_else(|| panic!("Failed to convert OsStr to str: {:?}", src_filepath));
+        .ok_or_else(|| {
+            Error::InvalidArguments(format!(
+                "Failed to convert OsStr to str: {:?}",
+                src_filepath
+            ))
+        })?;
 
     let object_file_name = if is_compile_only {
         // Compile only. We need to explicitly generate the object file


### PR DESCRIPTION
Replace `unimplemented!()` in file_utils.rs with error variants, `expect()` in path_utils.rs with Result propagation, and `unwrap()` on write() with proper error handling.