### PR TITLE
fix: correct is_bitcode_generation_skipped early-return logic

### DIFF
--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -426,9 +426,6 @@ impl CompilerArgsInfo {
     }
 
     pub fn is_bitcode_generation_skipped(&self) -> bool {
-        let mut is_skipped = false;
-        let mut message = "no reason";
-
         let conditions = [
             (
                 rllvm_config().is_configure_only(),
@@ -467,16 +464,12 @@ impl CompilerArgsInfo {
 
         for (condition, reason) in conditions {
             if condition {
-                is_skipped = true;
-                message = reason;
+                log::warn!("Skip bitcode generation: {}", reason);
+                return true;
             }
         }
 
-        if is_skipped {
-            log::warn!("Skip bitcode generation: {}", message);
-        }
-
-        is_skipped
+        false
     }
 
     pub fn mode(&self) -> CompileMode {


### PR DESCRIPTION
## Changes

Rewrote `is_bitcode_generation_skipped()` to use early-return on first matching condition instead of iterating through all conditions.

**Before:** Loop overwrote `message` for every match, only logging the last match's reason.
**After:** Returns immediately on first match with correct reason.

## Why

The previous logic was misleading — it appeared to check all conditions but the logged reason could be wrong if multiple conditions matched.