### PR TITLE
refactor: replace panics with proper error propagation

### DIFF
--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -505,12 +505,12 @@ impl CompilerArgsInfo {
             if let Some(bitcode_store_path) = rllvm_config().bitcode_store_path() {
                 if bitcode_store_path.exists() {
                     // Obtain a new bitcode filename based on the hash of the source filepath
-                    if bitcode_filepath.file_name().is_some() {
+                    if let (Some(stem), Some(ext)) =
+                        (bitcode_filepath.file_stem(), bitcode_filepath.extension())
+                    {
                         let src_filepath_hash = calculate_filepath_hash(&src_filepath);
-                        let bitcode_file_stem =
-                            bitcode_filepath.file_stem().unwrap().to_string_lossy();
-                        let bitcode_file_ext =
-                            bitcode_filepath.extension().unwrap().to_string_lossy();
+                        let bitcode_file_stem = stem.to_string_lossy();
+                        let bitcode_file_ext = ext.to_string_lossy();
 
                         let new_bitcode_filename =
                             format!("{bitcode_file_stem}_{src_filepath_hash}.{bitcode_file_ext}");

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// Missing file
     #[error("Missing file: {0}")]
     MissingFile(String),
+    /// Unsupported binary format
+    #[error("Unsupported format: {0}")]
+    UnsupportedFormat(String),
     /// Something else happened
     #[error("Unknown error: {0}")]
     Unknown(String),

--- a/src/utils/path_utils.rs
+++ b/src/utils/path_utils.rs
@@ -24,21 +24,44 @@ where
     }
 
     // Parent directory
-    let parent_dir = src_filepath
-        .parent()
-        .unwrap_or_else(|| panic!("Failed to obtain the parent directory: {:?}", src_filepath));
+    let parent_dir = src_filepath.parent().ok_or_else(|| {
+        Error::InvalidArguments(format!(
+            "Failed to obtain the parent directory: {:?}",
+            src_filepath
+        ))
+    })?;
     // With extension
     let file_name = src_filepath
         .file_name()
-        .unwrap_or_else(|| panic!("Failed to obtain the file name: {:?}", src_filepath))
+        .ok_or_else(|| {
+            Error::InvalidArguments(format!(
+                "Failed to obtain the file name: {:?}",
+                src_filepath
+            ))
+        })?
         .to_str()
-        .unwrap_or_else(|| panic!("Failed to convert OsStr to str: {:?}", src_filepath));
+        .ok_or_else(|| {
+            Error::StringError(format!(
+                "Failed to convert OsStr to str: {:?}",
+                src_filepath
+            ))
+        })?;
     // Without extension
     let file_stem = src_filepath
         .file_stem()
-        .unwrap_or_else(|| panic!("Failed to obtain the file stem: {:?}", src_filepath))
+        .ok_or_else(|| {
+            Error::InvalidArguments(format!(
+                "Failed to obtain the file stem: {:?}",
+                src_filepath
+            ))
+        })?
         .to_str()
-        .unwrap_or_else(|| panic!("Failed to convert OsStr to str: {:?}", src_filepath));
+        .ok_or_else(|| {
+            Error::StringError(format!(
+                "Failed to convert OsStr to str: {:?}",
+                src_filepath
+            ))
+        })?;
 
     let object_file_name = if is_compile_only {
         // Compile only. We need to explicitly generate the object file


### PR DESCRIPTION
## Changes

- Add `UnsupportedFormat(String)` error variant
- Replace `unimplemented!()` with `Err(Error::UnsupportedFormat(...))` in file_utils.rs
- Replace `.write().unwrap()` with `?` propagation
- Replace `.unwrap_or_else(|| panic!(...))` with `.ok_or_else(|| Error::...)?` in path_utils.rs
- Replace `.unwrap()` in copy_object_file with proper error handling
- Fix panic-prone glob handling in llvm_utils.rs

## Why

Library code should never panic. All error paths now return `Result` so callers can handle failures gracefully.