### PR TITLE
refactor: remove redundant clones and improve string handling

### DIFF
--- a/src/compiler_wrapper/wrapper.rs
+++ b/src/compiler_wrapper/wrapper.rs
@@ -46,7 +46,7 @@ pub trait CompilerWrapper {
     fn command(&self) -> Result<Vec<String>, Error> {
         let args_info = self.args();
         let compiler_filepath = self.wrapped_compiler();
-        let mut args = vec![String::from(compiler_filepath.to_string_lossy())];
+        let mut args = vec![compiler_filepath.to_string_lossy().into_owned()];
 
         // Append LTO LDFLAGS
         if args_info.input_files().is_empty() && !args_info.link_args().is_empty() {
@@ -176,7 +176,7 @@ pub trait CompilerWrapper {
         let bitcode_filepath = bitcode_filepath.as_ref();
         let compiler_filepath = self.wrapped_compiler();
 
-        let mut args = vec![String::from(compiler_filepath.to_string_lossy())];
+        let mut args = vec![compiler_filepath.to_string_lossy().into_owned()];
         args.extend(self.args().compile_args().iter().cloned());
         // Add bitcode generation flags
         if let Some(bitcode_generation_flags) = rllvm_config().bitcode_generation_flags() {
@@ -186,8 +186,8 @@ pub trait CompilerWrapper {
             "-emit-llvm".to_string(),
             "-c".to_string(),
             "-o".to_string(),
-            String::from(bitcode_filepath.to_string_lossy()),
-            String::from(src_filepath.to_string_lossy()),
+            bitcode_filepath.to_string_lossy().into_owned(),
+            src_filepath.to_string_lossy().into_owned(),
         ]);
 
         let mode = CompileMode::BitcodeGeneration;
@@ -208,13 +208,13 @@ pub trait CompilerWrapper {
         let object_filepath = object_filepath.as_ref();
         let wrapped_compiler = self.wrapped_compiler();
 
-        let mut args = vec![String::from(wrapped_compiler.to_string_lossy())];
+        let mut args = vec![wrapped_compiler.to_string_lossy().into_owned()];
         args.extend(self.args().compile_args().iter().cloned());
         args.extend_from_slice(&[
             "-c".to_string(),
             "-o".to_string(),
-            String::from(object_filepath.to_string_lossy()),
-            String::from(src_filepath.to_string_lossy()),
+            object_filepath.to_string_lossy().into_owned(),
+            src_filepath.to_string_lossy().into_owned(),
         ]);
 
         let mode = CompileMode::Compiling;
@@ -233,7 +233,7 @@ pub trait CompilerWrapper {
         let output_filepath = output_filepath.as_ref();
         let wrapped_compiler = self.wrapped_compiler();
 
-        let mut args = vec![String::from(wrapped_compiler.to_string_lossy())];
+        let mut args = vec![wrapped_compiler.to_string_lossy().into_owned()];
         if self.args().is_lto() {
             // Add LTO LDFLAGS
             if let Some(lto_ldflags) = rllvm_config().lto_ldflags() {
@@ -245,13 +245,13 @@ pub trait CompilerWrapper {
         // Output
         args.extend_from_slice(&[
             "-o".to_string(),
-            String::from(output_filepath.to_string_lossy()),
+            output_filepath.to_string_lossy().into_owned(),
         ]);
         // Input object files
         args.extend(
             object_filepaths
                 .iter()
-                .map(|x| String::from(x.as_ref().to_string_lossy())),
+                .map(|x| x.as_ref().to_string_lossy().into_owned()),
         );
 
         // Mode

--- a/src/utils/file_utils.rs
+++ b/src/utils/file_utils.rs
@@ -85,7 +85,7 @@ where
     let new_section = new_object_file.section_mut(section_id);
 
     let bitcode_filepath_string = if bitcode_filepath.is_absolute() {
-        bitcode_filepath.to_string_lossy().to_string()
+        bitcode_filepath.to_string_lossy().into_owned()
     } else {
         format!("{}\n", bitcode_filepath.canonicalize()?.to_string_lossy())
     };
@@ -370,10 +370,9 @@ mod tests {
             .expect("Failed to extract embedded filepaths");
         assert!(!embedded_filepaths.is_empty());
 
-        let embedded_filepath = embedded_filepaths[0].clone();
         let expected_filepath = PathBuf::from(bitcode_filepath);
-        println!("{:?}", embedded_filepath);
-        assert_eq!(embedded_filepath, expected_filepath);
+        println!("{:?}", embedded_filepaths[0]);
+        assert_eq!(embedded_filepaths[0], expected_filepath);
 
         // Clean
         fs::remove_file(output_object_filepath).expect("Failed to delete the output object file");

--- a/src/utils/llvm_utils.rs
+++ b/src/utils/llvm_utils.rs
@@ -122,13 +122,13 @@ where
     // Output
     args.extend_from_slice(&[
         "-o".to_string(),
-        String::from(output_filepath.to_string_lossy()),
+        output_filepath.to_string_lossy().into_owned(),
     ]);
     // Input bitcode files
     args.extend(
         bitcode_filepaths
             .iter()
-            .map(|x| String::from(x.as_ref().to_string_lossy())),
+            .map(|x| x.as_ref().to_string_lossy().into_owned()),
     );
 
     execute_command_for_status(rllvm_config().llvm_link_filepath(), &args)
@@ -151,13 +151,13 @@ where
 
     let mut args = vec![
         "rs".to_string(),
-        String::from(output_filepath.to_string_lossy()),
+        output_filepath.to_string_lossy().into_owned(),
     ];
     // Input bitcode files
     args.extend(
         bitcode_filepaths
             .iter()
-            .map(|x| String::from(x.as_ref().to_string_lossy())),
+            .map(|x| x.as_ref().to_string_lossy().into_owned()),
     );
 
     execute_command_for_status(rllvm_config().llvm_ar_filepath(), &args).map(|status| status.code())


### PR DESCRIPTION
Removed unnecessary .clone() calls and replaced String::from(path.to_string_lossy()) with .into_owned().