### PR TITLE
feat: add rllvm-info bitcode analysis tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ path = "src/bin/rllvm_init.rs"
 name = "rllvm-completions"
 path = "src/bin/rllvm_completions.rs"
 
+[[bin]]
+name = "rllvm-info"
+path = "src/bin/rllvm_info.rs"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src/bin/rllvm_info.rs
+++ b/src/bin/rllvm_info.rs
@@ -1,0 +1,105 @@
+use std::{fs, path::PathBuf};
+
+use clap::Parser;
+use owo_colors::OwoColorize;
+use rllvm::{
+    bitcode_info::{BitcodeInfo, analyze_bitcode},
+    error::Error,
+    utils::extract_bitcode_filepaths_from_object_file,
+};
+
+/// Analyze LLVM bitcode files
+#[derive(Parser, Debug)]
+#[command(
+    name = "rllvm-info",
+    about = "Display information about LLVM bitcode files",
+    author = "Shengtuo Hu <h1994st@gmail.com>",
+    version
+)]
+struct InfoArgs {
+    /// Input file (bitcode .bc or object file with embedded bitcode)
+    input: PathBuf,
+
+    /// List all function names
+    #[arg(short = 'f', long)]
+    functions: bool,
+}
+
+/// Detect whether a file is an LLVM bitcode file by checking its magic bytes.
+fn is_bitcode_file(path: &PathBuf) -> Result<bool, Error> {
+    let data = fs::read(path)?;
+    // LLVM bitcode files start with 'BC' (0x42, 0x43) magic
+    Ok(data.len() >= 2 && data[0] == 0x42 && data[1] == 0x43)
+}
+
+/// Try to parse as an object file to check for embedded bitcode.
+fn try_extract_bitcode_from_object(path: &PathBuf) -> Result<Option<PathBuf>, Error> {
+    let data = fs::read(path)?;
+    if object::File::parse(&*data).is_ok() {
+        let bc_paths = extract_bitcode_filepaths_from_object_file(path)?;
+        if let Some(first) = bc_paths.into_iter().next() {
+            if first.exists() {
+                return Ok(Some(first));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn print_info(info: &BitcodeInfo, show_functions: bool) {
+    println!("{}", "=== Bitcode Info ===".bold());
+    println!("File         : {}", info.file_path.display());
+    println!("File size    : {} bytes", info.file_size);
+    if let Some(triple) = &info.target_triple {
+        println!("Target triple: {}", triple);
+    }
+    if let Some(layout) = &info.data_layout {
+        println!("Data layout  : {}", layout);
+    }
+    println!("Functions    : {}", info.functions.len());
+    println!("Basic blocks : {}", info.total_basic_blocks);
+    println!("Instructions : {}", info.total_instructions);
+
+    if show_functions && !info.functions.is_empty() {
+        println!();
+        println!("{}", "=== Functions ===".bold());
+        for func in &info.functions {
+            println!(
+                "  {} (blocks: {}, instructions: {})",
+                func.name.green(),
+                func.basic_block_count,
+                func.instruction_count,
+            );
+        }
+    }
+}
+
+fn main() -> Result<(), Error> {
+    let args = InfoArgs::parse();
+
+    let input = &args.input;
+    let input_path = input
+        .canonicalize()
+        .map_err(|e| Error::MissingFile(format!("Cannot resolve input path {:?}: {}", input, e)))?;
+
+    // Determine the bitcode file to analyze
+    let bc_path = if is_bitcode_file(&input_path)? {
+        input_path
+    } else {
+        // Try extracting from an object file
+        match try_extract_bitcode_from_object(&input_path)? {
+            Some(path) => path,
+            None => {
+                return Err(Error::InvalidArguments(format!(
+                    "{} is not a bitcode file and no embedded bitcode was found",
+                    input.display()
+                )));
+            }
+        }
+    };
+
+    let info = analyze_bitcode(&bc_path)?;
+    print_info(&info, args.functions);
+
+    Ok(())
+}

--- a/src/bin/rllvm_init.rs
+++ b/src/bin/rllvm_init.rs
@@ -61,7 +61,10 @@ fn find_llvm_config_with_prefix(prefix: &Path) -> Result<PathBuf, Error> {
 fn detect_tools(llvm_prefix: Option<&Path>) -> Result<DetectedTools, Error> {
     // Step 1: Find llvm-config
     let llvm_config = if let Some(prefix) = llvm_prefix {
-        eprintln!("Searching for LLVM in user-specified prefix: {}", prefix.display());
+        eprintln!(
+            "Searching for LLVM in user-specified prefix: {}",
+            prefix.display()
+        );
         find_llvm_config_with_prefix(prefix)?
     } else {
         eprintln!("Auto-detecting LLVM installation...");
@@ -85,10 +88,7 @@ fn detect_tools(llvm_prefix: Option<&Path>) -> Result<DetectedTools, Error> {
 
     // Step 4: Check version consistency by querying clang --version
     if clang.exists() {
-        match std::process::Command::new(&clang)
-            .arg("--version")
-            .output()
-        {
+        match std::process::Command::new(&clang).arg("--version").output() {
             Ok(output) => {
                 let clang_version_output = String::from_utf8_lossy(&output.stdout);
                 if let Some(first_line) = clang_version_output.lines().next() {

--- a/src/bitcode_info.rs
+++ b/src/bitcode_info.rs
@@ -1,0 +1,259 @@
+//! Bitcode file analysis using `llvm-dis`.
+//!
+//! Parses disassembled LLVM IR to extract module-level metadata (target triple,
+//! data layout) and per-function statistics (basic block and instruction counts).
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    error::Error,
+    utils::{execute_command_for_stdout_string, find_llvm_config},
+};
+
+/// Information about a single function in the bitcode module.
+#[derive(Debug)]
+pub struct FunctionInfo {
+    pub name: String,
+    pub basic_block_count: usize,
+    pub instruction_count: usize,
+}
+
+/// Aggregated analysis of an LLVM bitcode file.
+#[derive(Debug)]
+pub struct BitcodeInfo {
+    pub file_path: PathBuf,
+    pub file_size: u64,
+    pub target_triple: Option<String>,
+    pub data_layout: Option<String>,
+    pub functions: Vec<FunctionInfo>,
+    pub total_basic_blocks: usize,
+    pub total_instructions: usize,
+}
+
+/// Locate the `llvm-dis` binary by deriving it from `llvm-config --bindir`.
+pub fn find_llvm_dis() -> Result<PathBuf, Error> {
+    let llvm_config = find_llvm_config()?;
+    let bindir = execute_command_for_stdout_string(&llvm_config, &["--bindir"])?;
+    let llvm_dis = PathBuf::from(bindir).join("llvm-dis");
+    if !llvm_dis.exists() {
+        return Err(Error::MissingFile(format!(
+            "llvm-dis not found at {}",
+            llvm_dis.display()
+        )));
+    }
+    Ok(llvm_dis)
+}
+
+/// Disassemble a bitcode file to LLVM IR text using `llvm-dis`.
+fn disassemble(llvm_dis: &Path, bc_path: &Path) -> Result<String, Error> {
+    execute_command_for_stdout_string(
+        llvm_dis,
+        &[bc_path.as_os_str(), "-o".as_ref(), "-".as_ref()],
+    )
+}
+
+/// Parse disassembled LLVM IR text into [`BitcodeInfo`].
+fn parse_ir(ir: &str, file_path: PathBuf, file_size: u64) -> BitcodeInfo {
+    let mut target_triple = None;
+    let mut data_layout = None;
+    let mut functions: Vec<FunctionInfo> = Vec::new();
+
+    // Parsing state
+    let mut current_func_name: Option<String> = None;
+    let mut current_bb_count: usize = 0;
+    let mut current_instr_count: usize = 0;
+
+    for line in ir.lines() {
+        let trimmed = line.trim();
+
+        // Module-level attributes
+        if let Some(rest) = trimmed.strip_prefix("target triple = \"") {
+            if let Some(value) = rest.strip_suffix('"') {
+                target_triple = Some(value.to_string());
+            }
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("target datalayout = \"") {
+            if let Some(value) = rest.strip_suffix('"') {
+                data_layout = Some(value.to_string());
+            }
+            continue;
+        }
+
+        // Function definition start: "define ... @name(...) {"
+        if trimmed.starts_with("define ") {
+            if let Some(name) = extract_function_name(trimmed) {
+                // Close any previous function (shouldn't happen with well-formed IR)
+                if let Some(prev_name) = current_func_name.take() {
+                    functions.push(FunctionInfo {
+                        name: prev_name,
+                        basic_block_count: current_bb_count,
+                        instruction_count: current_instr_count,
+                    });
+                }
+                current_func_name = Some(name);
+                current_bb_count = 0;
+                current_instr_count = 0;
+                // The entry block is implicit (first label after define)
+                // We count it when we see the first instruction or label
+                continue;
+            }
+        }
+
+        // Inside a function body
+        if current_func_name.is_some() {
+            // End of function
+            if trimmed == "}" {
+                if let Some(name) = current_func_name.take() {
+                    functions.push(FunctionInfo {
+                        name,
+                        basic_block_count: current_bb_count,
+                        instruction_count: current_instr_count,
+                    });
+                }
+                continue;
+            }
+
+            // Basic block label: "label:" or "N:" at the start of the line (not indented)
+            // In LLVM IR, labels are not indented and end with ':'
+            if !line.starts_with(' ') && !line.starts_with('\t') && trimmed.ends_with(':') {
+                current_bb_count += 1;
+                continue;
+            }
+
+            // Instructions are indented lines that are not comments or empty
+            if (line.starts_with(' ') || line.starts_with('\t'))
+                && !trimmed.is_empty()
+                && !trimmed.starts_with(';')
+            {
+                current_instr_count += 1;
+                // The first instruction implicitly starts the entry basic block
+                if current_bb_count == 0 {
+                    current_bb_count = 1;
+                }
+            }
+        }
+    }
+
+    let total_basic_blocks = functions.iter().map(|f| f.basic_block_count).sum();
+    let total_instructions = functions.iter().map(|f| f.instruction_count).sum();
+
+    BitcodeInfo {
+        file_path,
+        file_size,
+        target_triple,
+        data_layout,
+        functions,
+        total_basic_blocks,
+        total_instructions,
+    }
+}
+
+/// Extract the function name from a `define` line.
+///
+/// Looks for `@name(` pattern in the line.
+fn extract_function_name(line: &str) -> Option<String> {
+    let at_pos = line.find('@')?;
+    let after_at = &line[at_pos + 1..];
+    let end = after_at.find('(')?;
+    let name = &after_at[..end];
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Analyze a bitcode file and return structured information.
+///
+/// Locates `llvm-dis`, disassembles the bitcode, and parses the resulting IR.
+pub fn analyze_bitcode(bc_path: &Path) -> Result<BitcodeInfo, Error> {
+    let llvm_dis = find_llvm_dis()?;
+    let file_size = fs::metadata(bc_path).map_err(Error::Io)?.len();
+    let ir = disassemble(&llvm_dis, bc_path)?;
+    Ok(parse_ir(&ir, bc_path.to_path_buf(), file_size))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_function_name() {
+        assert_eq!(
+            extract_function_name("define i32 @main(i32 %argc, i8** %argv) {"),
+            Some("main".to_string())
+        );
+        assert_eq!(
+            extract_function_name("define internal void @helper() #0 {"),
+            Some("helper".to_string())
+        );
+        assert_eq!(
+            extract_function_name("declare void @llvm.dbg.value(...)"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_ir_basic() {
+        let ir = r#"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-apple-macosx15.0.0"
+
+define i32 @foo(i32 %x) {
+entry:
+  %add = add i32 %x, 1
+  ret i32 %add
+}
+
+define void @bar() {
+entry:
+  ret void
+}
+"#;
+        let info = parse_ir(ir, PathBuf::from("test.bc"), 1024);
+        assert_eq!(
+            info.target_triple.as_deref(),
+            Some("arm64-apple-macosx15.0.0")
+        );
+        assert_eq!(
+            info.data_layout.as_deref(),
+            Some("e-m:o-i64:64-i128:128-n32:64-S128-Fn32")
+        );
+        assert_eq!(info.functions.len(), 2);
+        assert_eq!(info.functions[0].name, "foo");
+        assert_eq!(info.functions[0].basic_block_count, 1);
+        assert_eq!(info.functions[0].instruction_count, 2);
+        assert_eq!(info.functions[1].name, "bar");
+        assert_eq!(info.functions[1].basic_block_count, 1);
+        assert_eq!(info.functions[1].instruction_count, 1);
+        assert_eq!(info.total_basic_blocks, 2);
+        assert_eq!(info.total_instructions, 3);
+    }
+
+    #[test]
+    fn test_parse_ir_multiple_blocks() {
+        let ir = r#"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @branch(i1 %cond) {
+entry:
+  br i1 %cond, label %then, label %else
+
+then:
+  ret i32 1
+
+else:
+  ret i32 0
+}
+"#;
+        let info = parse_ir(ir, PathBuf::from("test.bc"), 512);
+        assert_eq!(info.functions.len(), 1);
+        assert_eq!(info.functions[0].name, "branch");
+        assert_eq!(info.functions[0].basic_block_count, 3);
+        assert_eq!(info.functions[0].instruction_count, 3);
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -45,9 +45,8 @@ pub fn cache_dir(config_cache_dir: Option<&Path>) -> Result<PathBuf, Error> {
     let dir = if let Some(d) = config_cache_dir {
         d.to_path_buf()
     } else {
-        let home = env::var("HOME").map_err(|_| {
-            Error::ConfigError("HOME environment variable not set".into())
-        })?;
+        let home = env::var("HOME")
+            .map_err(|_| Error::ConfigError("HOME environment variable not set".into()))?;
         PathBuf::from(home).join(DEFAULT_CACHE_DIR)
     };
 
@@ -107,11 +106,7 @@ pub fn cached_bitcode_path(cache_dir: &Path, src_filepath: &Path, cache_key: u64
 }
 
 /// Looks up a cached bitcode file. Returns `Some(path)` if a valid cache entry exists.
-pub fn cache_lookup(
-    cache_dir: &Path,
-    src_filepath: &Path,
-    cache_key: u64,
-) -> Option<PathBuf> {
+pub fn cache_lookup(cache_dir: &Path, src_filepath: &Path, cache_key: u64) -> Option<PathBuf> {
     let cached_path = cached_bitcode_path(cache_dir, src_filepath, cache_key);
     if cached_path.exists() {
         CACHE_HITS.fetch_add(1, Ordering::Relaxed);

--- a/src/compiler_wrapper/wrapper.rs
+++ b/src/compiler_wrapper/wrapper.rs
@@ -140,7 +140,10 @@ pub trait CompilerWrapper {
             match cache::cache_dir(config.cache_dir().map(|p| p.as_path())) {
                 Ok(dir) => Some(dir),
                 Err(err) => {
-                    tracing::warn!("Failed to initialize cache directory, caching disabled: {}", err);
+                    tracing::warn!(
+                        "Failed to initialize cache directory, caching disabled: {}",
+                        err
+                    );
                     None
                 }
             }
@@ -170,24 +173,30 @@ pub trait CompilerWrapper {
                     config.bitcode_generation_flags(),
                 )?;
 
-                if let Some(cached_path) = cache::cache_lookup(cache_dir, &src_filepath, cache_key) {
+                if let Some(cached_path) = cache::cache_lookup(cache_dir, &src_filepath, cache_key)
+                {
                     // Cache hit — copy cached bitcode to expected output location
                     std::fs::copy(&cached_path, &bitcode_filepath).map_err(|err| {
                         tracing::error!(
                             "Failed to copy cached bitcode {:?} to {:?}: {}",
-                            cached_path, bitcode_filepath, err
+                            cached_path,
+                            bitcode_filepath,
+                            err
                         );
                         err
                     })?;
                     bitcode_filepath
                 } else {
                     // Cache miss — generate bitcode and store in cache
-                    if let Some(code) = self.generate_bitcode_file(&src_filepath, &bitcode_filepath)?
+                    if let Some(code) =
+                        self.generate_bitcode_file(&src_filepath, &bitcode_filepath)?
                         && code != 0
                     {
                         return Ok(Some(code));
                     }
-                    if let Err(err) = cache::cache_store(cache_dir, &src_filepath, cache_key, &bitcode_filepath) {
+                    if let Err(err) =
+                        cache::cache_store(cache_dir, &src_filepath, cache_key, &bitcode_filepath)
+                    {
                         tracing::warn!("Failed to store bitcode in cache: {}", err);
                     }
                     bitcode_filepath

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@ pub mod config;
 /// Compiler wrapper traits and LLVM/Clang implementation.
 pub mod compiler_wrapper;
 
+/// Bitcode file analysis via `llvm-dis`.
+pub mod bitcode_info;
+
 /// Error types used throughout the crate.
 pub mod error;
 


### PR DESCRIPTION
New binary for analyzing LLVM bitcode: function list, instruction count, target triple, etc.